### PR TITLE
My solution

### DIFF
--- a/solution.rb
+++ b/solution.rb
@@ -13,40 +13,28 @@ class LazyNumber
   end
 
   def evaluate(other)
-    other.value.send(@op, @value)
-  end
-end
-
-module NameToNumber
-  module_function
-
-  def number(name)
-    as_int = {:one => 1,
-              :two => 2,
-              :three => 3,
-              :four => 4,
-              :five => 5,
-              :six => 6,
-              :seven => 7,
-              :eight => 8,
-              :nine => 9}[name]
-    if as_int.nil?
-      nil
-    else
-      LazyNumber.new(as_int)
-    end
+    other.send(@op, @value)
   end
 end
 
 module Solution
-  def method_missing(name, *args, &block)
-    value = NameToNumber.number(name)
-    if value && args.size == 0
-      value
-    elsif value && args.size == 1
-      args.first.evaluate(value)
-    else
-      super
+  [
+    :one,
+    :two,
+    :three,
+    :four,
+    :five,
+    :six,
+    :seven,
+    :eight,
+    :nine
+  ].each_with_index.map do |name, ix|
+    define_method(name) do |other = nil|
+      if other.nil?
+        LazyNumber.new(ix + 1)
+      else
+        other.evaluate(ix + 1)
+      end
     end
   end
 

--- a/solution.rb
+++ b/solution.rb
@@ -1,1 +1,61 @@
 # Add your solution here
+
+class LazyNumber
+  attr_reader :value
+
+  def initialize(value)
+    @value = value
+  end
+
+  def prefix_op(op)
+    @op = op
+    self
+  end
+
+  def evaluate(other)
+    other.value.send(@op, @value)
+  end
+end
+
+module NameToNumber
+  module_function
+
+  def number(name)
+    as_int = {:one => 1,
+              :two => 2,
+              :three => 3,
+              :four => 4,
+              :five => 5,
+              :six => 6,
+              :seven => 7,
+              :eight => 8,
+              :nine => 9}[name]
+    if as_int.nil?
+      nil
+    else
+      LazyNumber.new(as_int)
+    end
+  end
+end
+
+module Solution
+  def method_missing(name, *args, &block)
+    value = NameToNumber.number(name)
+    if value && args.size == 0
+      value
+    elsif value && args.size == 1
+      args.first.evaluate(value)
+    else
+      super
+    end
+  end
+
+  {
+    times: :*,
+    plus: :+,
+    minus: :-,
+    divided_by: :/   # lol this one describes how I feel about doing this
+  }.each_pair.map do |k, v|
+    define_method(k) { |n|  n.prefix_op(v)}
+  end
+end

--- a/tests.rb
+++ b/tests.rb
@@ -2,6 +2,7 @@ require_relative 'solution'
 
 
 describe 'solution' do
+  include Solution
   it 'passes these tests' do
     expect(seven(times(five))).to eq 35
     expect(four(plus(nine))).to eq 13


### PR DESCRIPTION
I did two iterations.  The first one uses method_missing, which I really don't like to do, but it would theoretically be possible to add adapters that handle numbers other than 'one' through 'nine'.  The second version is more prescriptive of the methods that it defines, but is limited to manually defining the numbers that we want to use.

This would not handle compound operations (`three(plus(three(plus(three)))`) and order of operations (`two(times(one(plus(one))))`).  One possibility for that would be to delay evaluation until the `==` operator is used and build out the `LazyNumber` class with some kind of operation tree builder to figure out order of operations.

I could have avoided needing to `include Solution` in the tests by monkey patching `Object` or `RSpec::ExampleGroups::Solution`, but I couldn't bring myself to do that.